### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CHANGELOG
+
+## 1.2.0
 - mise à jour de laspy pour le correctif de la fonction `append_points`
 - Possibilité d'utiliser des points de montage pour rediriger les chemins donnés dans le shapefile vers un autre dossier
 - [Breaking change] Utilisation d'un shapefile pour définir les fichiers donneurs à utiliser pour chaque zone

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
- mise à jour de laspy pour le correctif de la fonction `append_points`
- Possibilité d'utiliser des points de montage pour rediriger les chemins donnés dans le shapefile vers un autre dossier
- [Breaking change] Utilisation d'un shapefile pour définir les fichiers donneurs à utiliser pour chaque zone
- génération de la carte d'indice même quand il n'y a pas de points à ajouter
